### PR TITLE
fix: set maximum length for image entity of models

### DIFF
--- a/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/constant/Constants.java
+++ b/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/constant/Constants.java
@@ -9,9 +9,10 @@ import java.util.Set;
 public class Constants {
     public static final String INTEGRATION_ID = "camthink-ai-inference";
     public static final String ATTRIBUTE_KEY_FORMAT = "format";
+    public static final String ATTRIBUTE_FORMAT_IMAGE = "IMAGE";
     public static final String ATTRIBUTE_FORMAT_IMAGE_BASE64 = "IMAGE:BASE64";
     public static final String ATTRIBUTE_FORMAT_IMAGE_URL = "IMAGE:URL";
-    public static final Set<String> ATTRIBUTE_FORMAT_IMAGE_SET = Set.of(ATTRIBUTE_FORMAT_IMAGE_BASE64, ATTRIBUTE_FORMAT_IMAGE_URL);
+    public static final Set<String> ATTRIBUTE_FORMAT_IMAGE_SET = Set.of(ATTRIBUTE_FORMAT_IMAGE, ATTRIBUTE_FORMAT_IMAGE_BASE64, ATTRIBUTE_FORMAT_IMAGE_URL);
     public static final String IDENTIFIER_MODEL_ID = "model_id";
     public static final String IDENTIFIER_MODEL_PREFIX = "model_";
     public static final String IDENTIFIER_MODEL_FORMAT = IDENTIFIER_MODEL_PREFIX + "{0}";

--- a/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/entity/ModelServiceInputEntityTemplate.java
+++ b/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/entity/ModelServiceInputEntityTemplate.java
@@ -1,6 +1,7 @@
 package com.milesight.beaveriot.integrations.camthinkaiinference.entity;
 
 import com.milesight.beaveriot.context.integration.enums.EntityValueType;
+import com.milesight.beaveriot.context.integration.model.AttributeBuilder;
 import com.milesight.beaveriot.context.integration.model.Entity;
 import com.milesight.beaveriot.context.integration.model.EntityBuilder;
 import com.milesight.beaveriot.integrations.camthinkaiinference.constant.Constants;
@@ -54,7 +55,9 @@ public class ModelServiceInputEntityTemplate {
     }
 
     private String convertFormat() {
-        if (format.contains("uri")) {
+        if (format.contains("uri") && format.contains("base64")) {
+            return Constants.ATTRIBUTE_FORMAT_IMAGE;
+        } else if (format.contains("uri")) {
             return Constants.ATTRIBUTE_FORMAT_IMAGE_URL;
         } else if (format.contains("base64")) {
             return Constants.ATTRIBUTE_FORMAT_IMAGE_BASE64;
@@ -65,22 +68,19 @@ public class ModelServiceInputEntityTemplate {
 
     private Map<String, Object> buildAttributes() {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put("optional", !required);
+        attributes.put(AttributeBuilder.ATTRIBUTE_OPTIONAL, !required);
         if (format != null) {
             String convertFormat = convertFormat();
-            attributes.put("format", convertFormat);
-            if (convertFormat.equals(Constants.ATTRIBUTE_FORMAT_IMAGE_URL)) {
-                attributes.put("max_length", Constants.IMAGE_URL_MAX_LENGTH);
-            }
+            attributes.put(AttributeBuilder.ATTRIBUTE_FORMAT, convertFormat);
         }
         if (defaultValue != null) {
-            attributes.put("default_value", defaultValue);
+            attributes.put(AttributeBuilder.ATTRIBUTE_DEFAULT_VALUE, defaultValue);
         }
         if (minimum != null) {
-            attributes.put("min", minimum);
+            attributes.put(AttributeBuilder.ATTRIBUTE_MIN, minimum);
         }
         if (maximum != null) {
-            attributes.put("max", maximum);
+            attributes.put(AttributeBuilder.ATTRIBUTE_MAX, maximum);
         }
         return attributes;
     }

--- a/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/service/CamThinkAiInferenceService.java
+++ b/integrations/camthink-ai-inference/src/main/java/com/milesight/beaveriot/integrations/camthinkaiinference/service/CamThinkAiInferenceService.java
@@ -9,6 +9,7 @@ import com.milesight.beaveriot.context.api.EntityServiceProvider;
 import com.milesight.beaveriot.context.api.EntityValueServiceProvider;
 import com.milesight.beaveriot.context.integration.enums.AttachTargetType;
 import com.milesight.beaveriot.context.integration.enums.EntityValueType;
+import com.milesight.beaveriot.context.integration.model.AttributeBuilder;
 import com.milesight.beaveriot.context.integration.model.Device;
 import com.milesight.beaveriot.context.integration.model.Entity;
 import com.milesight.beaveriot.context.integration.model.ExchangePayload;
@@ -617,8 +618,23 @@ public class CamThinkAiInferenceService {
 
             String modelKey = ModelServiceEntityTemplate.getModelKey(modelId);
             Entity modelServiceEntity = entityServiceProvider.findByKey(modelKey);
+            setImageEntityMaxLength(modelServiceEntity.getChildren());
             modelOutputSchemaResponse.setInputEntities(modelServiceEntity.getChildren());
         }
         return modelOutputSchemaResponse;
+    }
+
+    private void setImageEntityMaxLength(List<Entity> childrenEntity) {
+        if (childrenEntity == null) {
+            return;
+        }
+
+        childrenEntity.forEach(entity -> {
+            String format = entity.getAttributeStringValue(Constants.ATTRIBUTE_KEY_FORMAT);
+            if (Constants.ATTRIBUTE_FORMAT_IMAGE.equals(format) || Constants.ATTRIBUTE_FORMAT_IMAGE_URL.equals(format)) {
+                Map<String, Object> attributes = entity.getAttributes();
+                attributes.put(AttributeBuilder.ATTRIBUTE_MAX_LENGTH, Constants.IMAGE_URL_MAX_LENGTH);
+            }
+        });
     }
 }


### PR DESCRIPTION
Fix: Set maximum length for image entity of models during 'sync-detail' API call.