### PR TITLE
chore: create mqtt device only once during data uplink

### DIFF
--- a/integrations/mqtt-device/src/main/java/com/milesight/beaveriot/integrations/mqttdevice/service/MqttDeviceMqttService.java
+++ b/integrations/mqtt-device/src/main/java/com/milesight/beaveriot/integrations/mqttdevice/service/MqttDeviceMqttService.java
@@ -53,7 +53,9 @@ public class MqttDeviceMqttService {
                     Device device = result.getDevice();
                     ExchangePayload payload = result.getPayload();
                     if (device != null) {
-                        deviceServiceProvider.save(device);
+                        if (deviceServiceProvider.findByKey(device.getKey()) == null) {
+                            deviceServiceProvider.save(device);
+                        }
                         if (payload != null) {
                             entityValueServiceProvider.saveValuesAndPublishAsync(payload);
                         }


### PR DESCRIPTION
The MQTT device should be created only once during data uplink.